### PR TITLE
made following changes to endChannel.js

### DIFF
--- a/test/endChannel.js
+++ b/test/endChannel.js
@@ -4,98 +4,185 @@ const test = require('blue-tape')
 const p = require('util').promisify
 
 const {
-  ACCT_0_PRIVKEY,
-  ACCT_0_ADDR,
-  ACCT_1_PRIVKEY,
-  ACCT_1_ADDR,
+    ACCT_0_PRIVKEY,
+    ACCT_0_ADDR,
+    ACCT_1_PRIVKEY,
+    ACCT_1_ADDR,
+    ACCT_2_PRIVKEY,
+    ACCT_2_ADDR,
 } = require('./constants.js')
 
 const {
-  filterLogs,
-  takeSnapshot,
-  revertSnapshot,
-  solSha3,
-  sign,
-  mineBlocks,
-  createChannel,
-  updateState,
-  endChannel
+    filterLogs,
+    takeSnapshot,
+    revertSnapshot,
+    solSha3,
+    sign,
+    mineBlocks,
+    createChannel,
+    updateState,
+    endChannel
 } = require('./utils.js')
 
-module.exports = async (test, instance) => {
-  // endChannel happy path is tested in updateState.js
-  test('endChannel nonexistant channel', async t => {
-    const snapshot = await takeSnapshot()
+module.exports = async(test, instance) => {
+    // endChannel happy path is tested in updateState.js
+    test('endChannel nonexistant channel', async t => {
+        const snapshot = await takeSnapshot()
 
-    const channelId = '0x1000000000000000000000000000000000000000000000000000000000000000'
+        const channelId = '0x1000000000000000000000000000000000000000000000000000000000000000'
+        const string = 'newChannel'
 
-    await createChannel(
-      instance,
-      channelId,
-      6, 6,
-      2
-    )
+        await createChannel(
+            instance,
+            string,
+            channelId,
 
-    await updateState(
-      instance,
-      channelId,
-      1,
-      5, 7,
-      '0x'
-    )
+            6,
+            6,
 
-    t.shouldFail(endChannel(
-      instance,
-      '0x2000000000000000000000000000000000000000000000000000000000000000'
-    ))
+            2
+        )
 
-    await revertSnapshot(snapshot)
-  })
+        await updateState(
+            instance,
+            channelId,
+            1,
 
-  test('endChannel already ended', async t => {
-    const snapshot = await takeSnapshot()
+            5,
+            7,
 
-    const channelId = '0x1000000000000000000000000000000000000000000000000000000000000000'
+            '0x'
+        )
 
-    await createChannel(
-      instance,
-      channelId,
-      6, 6,
-      2
-    )
+        t.shouldFail(endChannel(
+            instance,
+            '0x2000000000000000000000000000000000000000000000000000000000000000'
+        ))
 
-    await updateState(
-      instance,
-      channelId,
-      1,
-      5, 7,
-      '0x'
-    )
+        await revertSnapshot(snapshot)
+    })
 
-    endChannel(
-      instance,
-      channelId
-    )
+    test('endChannel already ended', async t => {
+        const snapshot = await takeSnapshot()
 
-    t.shouldFail(endChannel(
-      instance,
-      channelId
-    ))
+        const channelId = '0x1000000000000000000000000000000000000000000000000000000000000000'
+        const string = 'newChannel'
 
-    await revertSnapshot(snapshot)
-  })
+        await createChannel(
+            instance,
+            string,
+            channelId,
 
-  test('endChannel bad sig', async t => {
-    const channelId = '0x1000000000000000000000000000000000000000000000000000000000000000'
+            6,
+            6,
 
-    const endChannelFingerprint = solSha3(
-      'UH OH',
-      channelId
-    )
+            2
+        )
 
-    t.shouldFail(instance.endChannel(
-      channelId,
-      sign(endChannelFingerprint, new Buffer(ACCT_0_PRIVKEY, 'hex'))
-    ))
-  })
+        await updateState(
+            instance,
+            channelId,
+            1,
+
+            5,
+            7,
+
+            '0x'
+        )
+
+        endChannel(
+            instance,
+            channelId
+        )
+
+        t.shouldFail(endChannel(
+            instance,
+            channelId
+        ))
+
+        await revertSnapshot(snapshot)
+    })
+
+    test('endChannel bad sig', async t => {
+        const snapshot = await takeSnapshot()
+
+        const channelId = '0x1000000000000000000000000000000000000000000000000000000000000000'
+        const string = 'newChannel'
+
+        const endChannelFingerprint = solSha3(
+            'endChannel derp',
+            channelId
+        )
+
+        await createChannel(
+            instance,
+            string,
+            channelId,
+
+            6,
+            6,
+
+            2
+        )
+
+        await updateState(
+            instance,
+            channelId,
+            1,
+
+            5,
+            7,
+
+            '0x'
+        )
+
+        t.shouldFail(instance.endChannel(
+            channelId,
+            sign(endChannelFingerprint, new Buffer(ACCT_0_PRIVKEY, 'hex'))
+        ))
+
+        await revertSnapshot(snapshot)
+    })
+
+
+    test('endChannel fake private key', async t => {
+        const snapshot = await takeSnapshot()
+
+        const channelId = '0x1000000000000000000000000000000000000000000000000000000000000000'
+        const string = 'newChannel'
+
+        const endChannelFingerprint = solSha3(
+            'endChannel',
+            channelId
+        )
+
+        await createChannel(
+            instance,
+            string,
+            channelId,
+
+            6,
+            6,
+
+            2
+        )
+
+        await updateState(
+            instance,
+            channelId,
+            1,
+
+            5,
+            7,
+
+            '0x'
+        )
+
+        t.shouldFail(instance.endChannel(
+            channelId,
+            sign(endChannelFingerprint, new Buffer(ACCT_2_PRIVKEY, 'hex'))
+        ))
+
+        await revertSnapshot(snapshot)
+    })
 }


### PR DESCRIPTION
- made changes to unit tests to support string arguement in 'createChannel' function
- updated 'endChannel bad sig' unit test for more control over 'endChannelFingerprint' function
- added 'endChannel fake private key' to test that signature containing key not belonging to any address is not used to end channel.